### PR TITLE
Fix crash caused by IntExtension

### DIFF
--- a/src/iTin.Core/Extensions/Int32Extensions.cs
+++ b/src/iTin.Core/Extensions/Int32Extensions.cs
@@ -93,7 +93,6 @@ namespace iTin.Core
         public static byte GetByte(this int value, Bytes onebyte)
         {
             SentinelHelper.IsEnumValid(onebyte);
-            SentinelHelper.IsTrue((byte)onebyte > 1);
 
             return value.GetByte((byte) onebyte);
         }
@@ -108,7 +107,7 @@ namespace iTin.Core
         /// <returns></returns>
         public static byte GetByte(this int value, byte onebyte)
         {
-            SentinelHelper.IsTrue(onebyte > 1);
+            SentinelHelper.IsTrue(onebyte > 3);
 
             return value.ToArray()[onebyte];
         }


### PR DESCRIPTION
the boundary limit of a int to byte array should be 3 instead of 1. 
since it's 4 bytes for a int32. 

this is a fix to the defect https://github.com/iAJTin/iSMBIOS/issues/1 